### PR TITLE
Build updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,16 +27,19 @@ CDESites/CancerGov/SiteSpecific/Modules/CancerGov.Search.Endeca/app.config
 
 CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.config
 CDESites/CancerGov/SiteSpecific/CancerGov.Web/Web.*.config
+CDESites/CancerGov/SiteSpecific/CancerGov.Web/localConfig/connectionStrings.config
 CDESites/DCEG/SiteSpecific/DCEG.Web/Web.config
 CDESites/DCEG/SiteSpecific/DCEG.Web/Web.*.config
 CDESites/Imaging/SiteSpecific/Imaging.Web/Web.config
 CDESites/Imaging/SiteSpecific/Imaging.Web/Web.config
 CDESites/MobileCancerGov/SiteSpecific/MobileCancerGov.Web/Web.config
 CDESites/MobileCancerGov/SiteSpecific/MobileCancerGov.Web/Web.*.config
+CDESites/MobileCancerGov/SiteSpecific/MobileCancerGov.Web/localConfig/connectionStrings.config
 CDESites/Proteomics/SiteSpecific/Proteomics.Web/Web.config
 CDESites/Proteomics/SiteSpecific/Proteomics.Web/Web.*.config
 CDESites/TCGA/SiteSpecific/TCGA.Web/Web.config
 CDESites/TCGA/SiteSpecific/TCGA.Web/Web.*.config
+CDESites/TCGA/SiteSpecific/TCGA.Web/localConfig/connectionStrings.config
 
 
 # /CDEFramework/Libraries/NCILibrary/Code/NCILibrary.CMS.Percussion/

--- a/CDESites/CancerGov/SiteSpecific/CancerGov.Web/localConfig/connectionStrings.config
+++ b/CDESites/CancerGov/SiteSpecific/CancerGov.Web/localConfig/connectionStrings.config
@@ -1,5 +1,0 @@
-<!--removed-->
-<!--removed-->
-<!--removed-->
-<!--removed-->
-<!--removed-->

--- a/CDESites/MobileCancerGov/SiteSpecific/MobileCancerGov.Web/localConfig/connectionStrings.config
+++ b/CDESites/MobileCancerGov/SiteSpecific/MobileCancerGov.Web/localConfig/connectionStrings.config
@@ -1,4 +1,0 @@
-<!--removed-->
-<!--removed-->
-<!--removed-->
-<!--removed-->

--- a/CDESites/TCGA/SiteSpecific/TCGA.Web/localConfig/connectionStrings.config
+++ b/CDESites/TCGA/SiteSpecific/TCGA.Web/localConfig/connectionStrings.config
@@ -1,3 +1,0 @@
-<!--removed-->
-<!--removed-->
-<!--removed-->

--- a/tools/build/BuildCDE.xml
+++ b/tools/build/BuildCDE.xml
@@ -84,7 +84,7 @@
 	<Exec Command="git tag $(BuildName) $(COMMIT_ID)" />
 
 	<Message Text="Uploading $(BuildName).zip to GitHub" />
-	<Exec Command="powershell -ExecutionPolicy RemoteSigned -NonInteractive scripts\github-release.ps1 -tagname $(BuildName) -releaseName $(BuildName) -commitId $(COMMIT_ID) -IsPreRelease -releaseNotes \&quot;Automated build $(BuildName)\&quot; -artifactDirectory &quot;$(TempBase)&quot; -artifactFileName &quot;$(BuildName).zip&quot; -gitHubUsername $(GITHUB_USER) -gitHubRepository $(GITHUB_REPO)" />
+	<Exec Command="powershell -ExecutionPolicy RemoteSigned -NonInteractive scripts\github-release.ps1 -tagname $(BuildName) -releaseName $(BuildName) -commitId $(COMMIT_ID) -IsPreRelease -releaseNotes \&quot;Automated build $(BuildName)\&quot; -artifactDirectory &quot;$(TempBase)&quot; -artifactFileName &quot;$(BuildName).zip&quot; -gitHubUsername $(GH_ORGANIZATION_NAME) -gitHubRepository $(GH_REPO_NAME)" />
   </Target>
 
   <!--

--- a/tools/build/BuildCDE.xml
+++ b/tools/build/BuildCDE.xml
@@ -33,8 +33,6 @@
   </PropertyGroup>
 
 
-
-
   <!--
     Build the solution and copy only the necessary files to the staging folder.
   -->
@@ -52,15 +50,15 @@
         Because of command-line length limits, configured properties (e.g. version number) are allowed to be imported
         from the build.config.
     -->
-    <Exec Command="for %%a in ($(CDE_Site_List)) do msbuild buildInner.xml /t:Build &quot;/p:CDE_Site=%%a;StagingLocation=$(StagingLocation);OutputFolder=$(OutputFolder);SourceLocation=$(SourceLocation);Revision=$(Revision);TargetEnvironment=$(TargetEnvironment)Branch=$(Branch)&quot;" />
+    <Exec Command="for %%a in ($(CDE_Site_List)) do msbuild buildInner.xml /t:Build &quot;/p:CDE_Site=%%a;StagingLocation=$(StagingLocation);OutputFolder=$(OutputFolder);SourceLocation=$(SourceLocation);Revision=$(Revision);TargetEnvironment=$(TargetEnvironment);Branch=$(Branch)&quot;" />
 
-	
+
 	<!--
 		Copy the CDE Schema into the CancerGov deliverable folder. All sites are assumed to be configured to reference
 		CancerGov's copy of the file.
 	-->
 	<Copy SourceFiles="$(SourceLocation)\CDESchema\CDESchema.xsd"		DestinationFolder="$(StagingLocation)\CancerGov\Schema"		OverwriteReadOnlyFiles="true" />
-	
+
 	<!--
 		Similar to the build, we want to execute the ConfigTransform target multiple times, with varying
 		combinations of CDE sites, environments, and preview/live.

--- a/tools/build/BuildInner.xml
+++ b/tools/build/BuildInner.xml
@@ -16,8 +16,8 @@
   <ItemGroup>
     <NonDeployedFiles Include="$(StagingLocation)\web.config" />
   </ItemGroup>
-  
-  
+
+
   <!--
     Build the solution and copy only the necessary files to the staging folder.
   -->
@@ -25,7 +25,7 @@
     <!--
       In order to make publishing work, we have to specify locations for
       both OutDir and WebProjectOutputDir.
-      
+
       OutDir is the location where Assemblies are created as they're individually
       built.  If this folder overlaps with WebProjectOutputDir, then we end up
       with extraneous executable files in the site root.
@@ -41,38 +41,40 @@
         Mirror="True" ExcludeFiles="*.config;*.pdb;" ExcludeFolders="sharedconfig"
     />
 
-    <!-- Clean up temporary output location, 
+    <!-- Clean up temporary output location,
     fake web.config and non-published file list. -->
     <Delete Files="@(NonDeployedFiles)" />
-    
+
     <!-- Write revision note file. -->
-    <WriteLinesToFile File="$(StagingLocation)/$(CDE_Site)/$(BuildNoteFile)" Lines="Version: branches $(Branch);" />
+    <WriteLinesToFile File="$(StagingLocation)/$(CDE_Site)/$(BuildNoteFile)" Lines="Version: $(Branch);" />
     <WriteLinesToFile File="$(StagingLocation)/$(CDE_Site)/$(BuildNoteFile)" Lines="Build Number: $(BUILD_NUMBER)" />
     <WriteLinesToFile File="$(StagingLocation)/$(CDE_Site)/$(BuildNoteFile)" Lines="Build Target: $(TargetEnvironment)" />
+	<WriteLinesToFile File="$(StagingLocation)/$(CDE_Site)/$(BuildNoteFile)" Lines="Commit: $(COMMIT_ID)" />
   </Target>
 
-  
+
   <Target Name="ConfigTransform">
-  
+
 	   <Message Text="SourceLocation = '$(SourceLocation)', ConfigFileLocation = '$(ConfigFileLocation)'" />
 	   <Message Text="CDE_Site = '$(CDE_Site)', ENVIRON = '$(ENVIRON)', SITE = '$(SITE)'" />
 
 	   <!-- Transform will fail if the output location doesn't already exist. -->
 	   <MakeDir Directories="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\"/>
-  
+
 	   <TransformXml   Source="$(SourceLocation)\CDESites\$(CDE_Site)\SiteSpecific\$(CDE_Site).Web\Web.config"
 					Transform="$(SourceLocation)\CDESites\$(CDE_Site)\SiteSpecific\$(CDE_Site).Web\Web.$(ENVIRON)-$(SITE).config"
 					Destination="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" />
 
     <!-- Write notes to config file. -->
-    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="&lt;!-- " />    
-    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Version: branches $(Branch);" />
+    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="&lt;!-- " />
+    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Version: $(Branch);" />
     <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Revision: $(Revision)" />
-    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Build Target: $(TargetEnvironment)" />      
-    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Source Transform: $(SourceLocation)\CDESites\$(CDE_Site)\SiteSpecific\$(CDE_Site).Web\Web.$(ENVIRON)-$(SITE).config" />          
-    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="--&gt;" />        
+    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Build Target: $(TargetEnvironment)" />
+	<WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Commit: $(COMMIT_ID)" />
+    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="Source Transform: $(SourceLocation)\CDESites\$(CDE_Site)\SiteSpecific\$(CDE_Site).Web\Web.$(ENVIRON)-$(SITE).config" />
+    <WriteLinesToFile File="$(ConfigFileLocation)\$(ENVIRON)\$(CDE_Site)\$(SITE)\code\Web.config" Lines="--&gt;" />
   </Target>
-  
+
   <!--
     Deploy the built code (.as?x and .dll) to the location set in
     the $(DeployLocation) value, defined in build.config.  (If the
@@ -83,7 +85,7 @@
     <Error Condition="$(CDE_Site) == '' OR $(StagingLocation) == '' OR $(TargetEnvironment) == '' OR $(ConfigFileLocation) == ''"
              Text="CDE_Site and StagingLocation must be specified.\nCDE_Site: $(CDE_Site)\nStagingLocation: $(StagingLocation)\nTargetEnvironment: $(TargetEnvironment)\nConfigFileLocation: $(ConfigFileLocation)"
     />
-    
+
     <!-- NOTE: *.config, robots.txt, and *.pdb are not copied. -->
     <RoboCopy
         SourceFolder="$(StagingLocation)\$(CDE_Site)"
@@ -98,7 +100,7 @@
 		DestinationFolder="$(DeployLocation)\$(CDE_Site)\Live\Code"
 		OverwriteReadOnlyFiles="true"
 	/>
-	
+
     <RoboCopy
         SourceFolder="$(StagingLocation)\$(CDE_Site)"
         DestinationFolder="$(DeployLocation)\$(CDE_Site)\Preview\Code"
@@ -106,18 +108,18 @@
         ExcludeFiles="*.config;robots.txt;*.pdb"
 		ExcludeFolders="localConfig"
     />
-	
+
 	<Copy
 		SourceFiles="$(ConfigFileLocation)\$(TargetEnvironment)\$(CDE_Site)\Preview\code\\Web.config"
 		DestinationFolder="$(DeployLocation)\$(CDE_Site)\Preview\Code"
 		OverwriteReadOnlyFiles="true"
 	/>
-	
+
   </Target>
 
   <Target Name="Help">
     <Message Text="This script is not intended to be run directly." />
     <Message Text="Please use BuildCDE.xml instead." />
   </Target>
-  
+
 </Project>

--- a/tools/build/build.config
+++ b/tools/build/build.config
@@ -4,7 +4,7 @@
     <!--
          Configuration File for BuildMaster.XML.  This file contains no build instructions
          and is intended only to provide configuration data used in BuildMaster.xml.
-		 
+
 		 Entries in this file should rarely change.
      -->
 
@@ -16,17 +16,10 @@
 
 	<!-- List of environments needing configuration files. -->
 	<Config_Environment_List>Blue Red Pink QA DT Training Stage COLO Prod</Config_Environment_List>
-	
+
 	<!-- List of sub-sites needing configuration files. (This is a confusing name.)
 		The full set of values will be Live and Preview. -->
 	<Config_Site_List>Preview Live</Config_Site_List>
-  
-
-	<!-- GitHub username or organization name.  e.g. NCIOCPL -->
-	<GITHUB_USER>NCIOCPL</GITHUB_USER>
-
-	<!-- The specific GitHub repository to use -->
-	<GITHUB_REPO>wcms-cde</GITHUB_REPO>
 
 
    <!-- Location where the built files are to be deployed.
@@ -37,7 +30,7 @@
   <DeployLocation>E:\content\PercussionSites\CDESites</DeployLocation>
 
 
-    
+
 	<!-- Name of the Visual Studio solution file for building the application. -->
 	<SolutionName>Content Delivery Engine.sln</SolutionName>
 


### PR DESCRIPTION
- Additional configuration files in the .gitignore list.
- Fix generation of the build.txt file to properly show the branch and build environment names.
- Add the Commit ID to build.txt
- Use environment variables instead to hard-coded values to determine the GitHub path.