### PR TITLE
Adding setting for TLS1.2 to allow Jenkins to build correctly.

### DIFF
--- a/tools/build/scripts/github-release.ps1
+++ b/tools/build/scripts/github-release.ps1
@@ -78,6 +78,10 @@ function GitHub-Release($tagname, $releaseName, $commitId, $IsPreRelease, $relea
         https://github.com/settings/tokens
 
     #>
+	
+	# GitHub has deprecated TLS v1 and v1.1 as of 2/22/2018: https://githubengineering.com/crypto-removal-notice/
+    # This sets PowerShell to use TLS v1.2
+	[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12;
 
     $draft = $FALSE
 


### PR DESCRIPTION
Included change to use TLS1.2 in the github-release PS script.

Since these are only changes to code used for Jenkins builds, they were not deployed to PROD.