### PR TITLE
Build fix (#24)

### DIFF
--- a/tools/jenkins/build_skeleton.job
+++ b/tools/jenkins/build_skeleton.job
@@ -36,7 +36,7 @@ job("Build for $BRANCH on $ENVIRONMENT") {
         name('origin')
         url("https://github.com/$sourceRepository")
       }
-      branch("*/$TARGET_BRANCH")
+      branch("*/$BRANCH")
       extensions {
         submoduleOptions {
           recursive(true)

--- a/tools/jenkins/integration_skeleton.job
+++ b/tools/jenkins/integration_skeleton.job
@@ -44,7 +44,7 @@ job("Integration build for $BRANCH on $ENVIRONMENT") {
         name('origin')
         url("https://github.com/$sourceRepository")
       }
-      branch("*/$TARGET_BRANCH")
+      branch("*/$BRANCH")
       extensions {
         submoduleOptions {
           recursive(true)

--- a/tools/jenkins/setup.job
+++ b/tools/jenkins/setup.job
@@ -4,27 +4,21 @@
     belong in this file.
 */
 
-def FOLDER_NAME  = 'wcms-cde'    // Jenkins folder where the jbos will be placed.
+def FOLDER_NAME  = 'wcms-cde'         // Jenkins folder where the jbos will be placed.
 
-def GH_REPO_NAME = 'wcms-cde'     // The project's repository name (as used in the URL).
-def TARGET_BRANCH = 'master'            // Branch to run against.
-def GH_ORGANIZATION_NAME = 'NCIOCPL'   // GitHub Organization name (as used in the URL/userid).
-def GH_USER_TOKEN_KEY = 'NCIOCPL-GitHub-Token'  // Jenkins ID of the credential string containing the GitHub access token for creating releases.
-def NEXUS_USER_KEY = 'NCIOCPL-Nexus-Credentials' // Jenkins ID of the credentials object containing the nexus repository userid and password.
+def GH_REPO_NAME = 'wcms-cde'         // The project's repository name (as used in the URL).
+def TARGET_BRANCH = 'master'          // Branch to load seed jobs from. (This should almost always be "master.")
+def GH_ORGANIZATION_NAME = 'NCIOCPL'  // GitHub Organization name (as used in the URL/userid).
+def GH_USER_TOKEN_KEY = 'NCIOCPL-GitHub-Token'    // Jenkins ID of the credential string containing the GitHub access token for creating releases.
+def NEXUS_USER_KEY = 'NCIOCPL-Nexus-Credentials'  // Jenkins ID of the credentials object containing the nexus repository userid and password.
 def CONFIG_SUBSTITUTIONS = 'WCMS-cde-config-substitutions-file' // Jenkins ID of the credentials object containing the CDE configuration substitution values.
 
 def sourceRepository = "$GH_ORGANIZATION_NAME/$GH_REPO_NAME"
 def toolsRepository = "$GH_ORGANIZATION_NAME/cancergov-build-tools"  // Where do we find the build tools.
 def toolsBranch = "cde"
 
-// Calculate the current folder path so the seed job is able to create jobs in the
-// current folder without the user remembering to set the context manually.
-// (Nested seed jobs - e.g. Create build job - do so by calling lookupStrategy.)
-def NAME_LENGTH = JOB_BASE_NAME.length()
-def FOLDER_PATH = JOB_NAME[0..((JOB_NAME.length() - NAME_LENGTH) - 2)]
 
-
-job("${FOLDER_PATH}/Create build job for a branch") {
+job("Create build job for a branch") {
   description("Creates the jobs that build individual branches.\n\nTo modify this job, see the contents of setup.job and create-branch-skeleton.job.")
 
   wrappers {
@@ -33,18 +27,17 @@ job("${FOLDER_PATH}/Create build job for a branch") {
         // Values common to the various scripts that we don't want to maintain in more than one place.
         FOLDER_NAME : FOLDER_NAME,
         GH_REPO_NAME : GH_REPO_NAME,
-        TARGET_BRANCH : TARGET_BRANCH,
         GH_ORGANIZATION_NAME : GH_ORGANIZATION_NAME,
         GH_USER_TOKEN_KEY : GH_USER_TOKEN_KEY,
         NEXUS_USER_KEY : NEXUS_USER_KEY,
-        CONFIG_SUBSTITUTIONS : CONFIG_SUBSTITUTIONS
+        CONFIG_SUBSTITUTIONS : CONFIG_SUBSTITUTIONS,
+        ENVIRONMENT : 'blue'
       )
     }
   }
 
   parameters {
     stringParam('BRANCH', '', 'New Branch\'s Name')
-    choiceParam('ENVIRONMENT', ['pink', 'blue', 'red'], 'WCMS build environment.\n\nBlue - Dev\nRed - Hotfixes\nPink - Special projects')
   }
 
   scm {


### PR DESCRIPTION
* Fix branch selection for build jobs.
  Build jobs were mistakenly configured to use the branch that the build job definition was retrieved from rather than the user-provided branch name.
* Remove folder location logic.
* Always build on blue.